### PR TITLE
[dev] `continuous_integration_build*`:split_between_ios_and_macos_add_caching

### DIFF
--- a/.github/workflows/continuous_integration_build_ios.yml
+++ b/.github/workflows/continuous_integration_build_ios.yml
@@ -1,4 +1,4 @@
-name: continuous_integration_build
+name: continuous_integration_build_ios
 on:
   push:
     branches: ["core"]
@@ -7,10 +7,10 @@ on:
 env:
   enabled_caching: 1
   enabled_caching_clic3: 1
-  key_cache_clic3: cache_clic3_0_0_0
-  target_device_version: 15.5
+  key_cache_clic3: cache_clic3_ios_0_0_0
+  target_device_version: 18.5
 jobs:
-  continuous_integration_build:
+  continuous_integration_build_ios:
     runs-on: macos-latest
     steps:
       - name: git_initialization
@@ -33,11 +33,11 @@ jobs:
         with:
           repository: alic3dev/clic3
           path: clic3
-      - name: make::clic3
+      - name: make::clic3_ios
         if: steps.cache_restore_clic3.outputs.cache-hit != 'true'
-        run: cd clic3 && make clic3_dylib target_device_version=${{ env.target_device_version }}
-      - name: make::rand
-        run: cd rand && make target_device_version=${{ env.target_device_version }}
+        run: cd clic3 && make clic3_ios_dylib target_device_version=${{ env.target_device_version }} target_device=iphone
+      - name: make:rand_ios
+        run: cd rand && make target_device_version=${{ env.target_device_version }} target_device=iphone
       - name: cache_save_clic3
         id: cache_save_clic3
         if: ${{ env.enabled_caching == '1' && env.enabled_caching_clic3 == '1' && steps.cache_restore_clic3.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
- `continuous_integration_build`:
- - split_ios
- - add_caching
- - only build `dylib` for `clic3`
- `continuous_integration_build_ios`:add