### PR TITLE
[enh] `rand_seed`:add_process_byte

### DIFF
--- a/sources/rand_seed.c
+++ b/sources/rand_seed.c
@@ -4,18 +4,20 @@
 
 #include <sys/sysctl.h>
 #include <sys/time.h>
-
-#include <stdio.h>
+#include <unistd.h>
 
 void rand_seed_generate(
   unsigned char* rand_seed_buffer,
   unsigned long long int length_rand_seed_buffer
 ) {
+  int identifier_process = (
+    getpid()
+  );
   struct timeval timeval;
 
   gettimeofday(
     &timeval,
-    0
+    0x00
   );
 
   unsigned char bytes_time_val_sec[
@@ -37,6 +39,10 @@ void rand_seed_generate(
     &timeval.tv_usec,
     0x03
   );
+  
+  unsigned char byte = (
+    0x00
+  );
 
   for (
     unsigned long long int index_rand_seed = (
@@ -48,11 +54,21 @@ void rand_seed_generate(
     );
     ++index_rand_seed
   ) {
+    byte = (
+      byte +
+      identifier_process +
+      identifier_process *
+      (
+        identifier_process +
+        index_rand_seed
+      )
+    );  
     rand_seed_buffer[
       index_rand_seed
     ] = (
       index_rand_seed *
-      length_rand_seed_buffer
+      length_rand_seed_buffer +
+      byte
     );
 
     rand_seed_buffer[
@@ -67,7 +83,19 @@ void rand_seed_generate(
         index_rand_seed
       )
     );
-
+    
+    byte = (
+      byte +
+      rand_seed_buffer[
+        byte %
+        length_rand_seed_buffer
+      ] +
+      bytes_time_val_usec[
+        byte %
+        0x03
+      ] *
+      byte
+    );
     rand_seed_buffer[
       index_rand_seed
     ] = (
@@ -78,28 +106,44 @@ void rand_seed_generate(
       (
         (unsigned long long int)
         bytes_time_val_usec[
-          index_rand_seed %
+          (
+            byte +
+            index_rand_seed
+          ) %
           0x03
         ] *
         (
           (
-            index_rand_seed %
-            0x03
-          ) ==
-          0x01
-          ? 1.0f
+            (
+              index_rand_seed %
+              0x03
+            ) ==
+            0x01
+          )
+          ? 0x01
           : (
-            index_rand_seed %
-            0x03
-          ) ==
-          0x02
-          ? index_rand_seed
-          : (
-            length_rand_seed_buffer -
-            index_rand_seed
+            (
+              (
+                index_rand_seed %
+                0x03
+              ) ==
+              0x02
+            )
+            ? index_rand_seed
+            : (
+              length_rand_seed_buffer -
+              index_rand_seed
+            )
           )
         )
       )
+    );
+    
+    byte = (
+      byte +
+      byte *
+      0x03 +
+      index_rand_seed
     );
 
     rand_seed_buffer[
@@ -112,18 +156,34 @@ void rand_seed_generate(
       (
         (unsigned long long int)
         bytes_time_val_sec[
-          0x00
+          byte %
+          0x04
         ] *
         (
-          index_rand_seed %
           (
-            bytes_time_val_usec[
-              0x00
-            ] *
-            13
-          )
+            index_rand_seed %
+            (
+              bytes_time_val_usec[
+                0x00
+              ] *
+              0x0d
+            )
+          ) +
+          0x01
         )
       )
+    );
+    
+    byte = (
+      byte +
+      rand_seed_buffer[
+        byte %
+        length_rand_seed_buffer
+      ] +
+      byte /
+      0x02 +
+      byte *
+      index_rand_seed
     );
     
     rand_seed_buffer[
@@ -139,7 +199,20 @@ void rand_seed_generate(
           0x01
         ] *
         length_rand_seed_buffer
-      )
+      ) +
+      byte
+    );
+    
+    byte = (
+      byte *
+      byte +
+      bytes_time_val_usec[
+        (
+          index_rand_seed +
+          byte
+        ) %
+        0x03
+      ]
     );
 
     rand_seed_buffer[
@@ -152,6 +225,16 @@ void rand_seed_generate(
       (unsigned long long int)
       bytes_time_val_sec[
         0x02
+      ] -
+      byte
+    );
+    
+    byte = (
+      byte +
+      byte *
+      bytes_time_val_sec[
+        byte %
+        0x04
       ]
     );
 
@@ -165,7 +248,8 @@ void rand_seed_generate(
       (unsigned long long int)
       bytes_time_val_sec[
         0x03
-      ]
+      ] +
+      byte
     );
 
     if (


### PR DESCRIPTION
- `rand_seed`:add_process_byte
- - makes this a bit less dependent soley upon time values
- - random generation for divisive generation is less likely to fall into repetition